### PR TITLE
Unified logging to persistent data folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ EXPOSE 5000
 RUN sed -i s=FreeTAKServerDataPackageDataBase.db=/data/DataPackageDataBase.db=g /usr/local/lib/python3.8/dist-packages/FreeTAKServer/controllers/configuration/DataPackageServerConstants.py && \
     sed -i s=FreeTAKServerDataPackageFolder=/data/DataPackageFolder=g /usr/local/lib/python3.8/dist-packages/FreeTAKServer/controllers/configuration/DataPackageServerConstants.py && \
     sed -i "s+self.PARENTPATH = .*+self.PARENTPATH = '\/data'+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer/controllers/configuration/LoggingConstants.py && \
-    sed -i "s+self.LOGDIRECTORY = .*+sself.LOGDIRECTORY = 'logs'+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer/controllers/configuration/LoggingConstants.py &&\
+    sed -i "s+self.LOGDIRECTORY = .*+self.LOGDIRECTORY = 'logs'+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer/controllers/configuration/LoggingConstants.py &&\
     sed -i 's+DBFilePath = .*+DBFilePath = "/data/FTSDataBase.db"+g' /usr/local/lib/python3.8/dist-packages/FreeTAKServer/controllers/configuration/MainConfig.py && \
     sed -e '52d;53d' -i /usr/local/lib/python3.8/dist-packages/FreeTAKServer/controllers/configuration/MainConfig.py &&\
     sed -e '52i\ \ \ \ MainPath = "/data"' -i /usr/local/lib/python3.8/dist-packages/FreeTAKServer/controllers/configuration/MainConfig.py &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,8 @@ EXPOSE 5000
 # The last two seds here are dirty and should be changed, this will break if main config changes!
 RUN sed -i s=FreeTAKServerDataPackageDataBase.db=/data/DataPackageDataBase.db=g /usr/local/lib/python3.8/dist-packages/FreeTAKServer/controllers/configuration/DataPackageServerConstants.py && \
     sed -i s=FreeTAKServerDataPackageFolder=/data/DataPackageFolder=g /usr/local/lib/python3.8/dist-packages/FreeTAKServer/controllers/configuration/DataPackageServerConstants.py && \
-    sed -i s='logs'='/data/logs'=g /usr/local/lib/python3.8/dist-packages/FreeTAKServer/controllers/configuration/LoggingConstants.py && \
+    sed -i "s+self.PARENTPATH = .*+self.PARENTPATH = '\/data'+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer/controllers/configuration/LoggingConstants.py && \
+    sed -i "s+self.LOGDIRECTORY = .*+sself.LOGDIRECTORY = 'logs'+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer/controllers/configuration/LoggingConstants.py &&\
     sed -i 's+DBFilePath = .*+DBFilePath = "/data/FTSDataBase.db"+g' /usr/local/lib/python3.8/dist-packages/FreeTAKServer/controllers/configuration/MainConfig.py && \
     sed -e '52d;53d' -i /usr/local/lib/python3.8/dist-packages/FreeTAKServer/controllers/configuration/MainConfig.py &&\
     sed -e '52i\ \ \ \ MainPath = "/data"' -i /usr/local/lib/python3.8/dist-packages/FreeTAKServer/controllers/configuration/MainConfig.py &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN addgroup --gid 1000 fts && \
 #    chmod 775 /var/log
 
 # Container friendly supervisor
-RUN mkdir -p /var/log/supervisor/ && \
-    chown -R fts:fts /var/log/supervisor
+RUN mkdir -p /data/logs/supervisor/ && \
+    chown -R fts:fts /data/logs/supervisor
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 COPY fatalexit /usr/local/bin/fatalexit

--- a/ftsrotate
+++ b/ftsrotate
@@ -1,4 +1,4 @@
-/data/log/supervisor/*.log {
+/data/logs/supervisor/*.log {
   daily
   rotate 60
   copytruncate

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,8 +1,8 @@
 [supervisord]
 nodaemon=true
-logfile=/var/log/supervisor/supervisord.log
-stderror_logfile=/var/log/supervisor/stderr.log
-stdout_logfile=/var/log/supervisor/stdout.log
+logfile=/data/logs/supervisor/supervisord.log
+stderror_logfile=/data/logs/supervisor/stderr.log
+stdout_logfile=/data/logs/supervisor/stdout.log
 redirect_stderr=true
 file=/home/fts/supervisor.sock
 user=root
@@ -14,8 +14,8 @@ PIDFILE=/home/fts/suporvisord.pid
 command=python3 -m FreeTAKServer.controllers.services.FTS
 autostart=true
 autorestart=true
-stderr_logfile=/var/log/supervisor/FTS_stderr.log
-stdout_logfile=/var/log/supervisor/FTS_stdout.log
+stderr_logfile=/data/logs/supervisor/FTS_stderr.log
+stdout_logfile=/data/logs/supervisor/FTS_stdout.log
 stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
 stdout_logfile_backups=0
@@ -28,8 +28,8 @@ command=bash -c "FLASK_APP=/usr/local/lib/python3.8/dist-packages/FreeTAKServer-
 autostart=true
 autorestart=true
 startretries=999
-stderr_logfile=/var/log/supervisor/UI_stderr.log
-stdout_logfile=/var/log/supervisor/UI_stdout.log
+stderr_logfile=/data/logs/supervisor/UI_stderr.log
+stdout_logfile=/data/logs/supervisor/UI_stdout.log
 stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
 stdout_logfile_backups=0


### PR DESCRIPTION
Everything we currently control of logs now reside in the proper folder, log rotation for supervisord is also added. We might want to extend log rotation in the future. 