### PR TITLE
Add more configuration options and example docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3"
+
+services:
+  takserver:
+    image: freetakteam/freetakserver:dev
+    container_name: takserver
+    environment:
+      # FTS
+      - FTS_COT_TO_DB=True
+      - FTS_CONNECTION_MESSAGE="my tak server"
+      # UI
+      - APPIP=0.0.0.0
+      - APPPORT=5000
+      - APIIP=0.0.0.0
+      - APIPORT=19023
+      - APIPROTOCOL=http
+      - WEBMAPIP=0.0.0.0
+      - WEBMAPPORT=8000
+      - WEBMAPPROTOCOL=http
+    restart: unless-stopped
+    volumes:
+      - ./data:/data
+    ports:
+      - "8080:8080"
+      - "8443:8443"
+      - "8087:8087"
+      - "8089:8089"
+    expose:
+      # API port
+      - "19023"
+      # UI port
+      - "5000"

--- a/start-fts.sh
+++ b/start-fts.sh
@@ -18,20 +18,73 @@ chmod -R 777 /data
 
 #UI Variables
 
-#IP
-if [ -z "${IP}" ]; then
-  echo "Using default IP 127.0.0.1"
+#If APIIP specified, use that, otherwise use IP
+if [ -z "${APIIP}" ]; then
+  if [ -z "${IP}" ]; then
+    echo "Using default APIIP 127.0.0.1"
+  else
+     echo "Setting APIIP: ${IP}"
+      sed -i "s+IP = .*+IP = '"${IP}"'+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer-UI/config.py
+  fi
 else
-   echo "Setting IP: ${IP}"
-    sed -i "s+IP = .*+IP = '"${IP}"'+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer-UI/config.py
+   echo "Setting APIIP: ${APIIP}"
+    sed -i "s+IP = .*+IP = '"${APIIP}"'+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer-UI/config.py
+  fi
+
+#APIPORT
+if [ -z "${APIPORT}" ]; then
+  echo "Using default APIPORT 19023"
+else
+   echo "Setting APIPORT: ${APIPORT}"
+    sed -i "s+PORT = .*+PORT = '"${APIPORT}"'+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer-UI/config.py
+  fi
+
+#APIPROTOCOL
+if [ -z "${APIPROTOCOL}" ]; then
+  echo "Using default APIPROTOCOL http"
+else
+   echo "Setting APIPROTOCOL: ${APIPROTOCOL}"
+    sed -i "s+PROTOCOL = .*+PROTOCOL = '"${APIPROTOCOL}"'+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer-UI/config.py
   fi
 
 #APPIP
 if [ -z "${APPIP}" ]; then
-  echo "Using default IP 127.0.0.1"
+  echo "Using default APPIP 127.0.0.1"
 else
    echo "Setting APPIP: ${APPIP}"
     sed -i "s+APPIP = .*+APPIP = '"${APPIP}"'+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer-UI/config.py
+  fi
+
+#APPPORT
+if [ -z "${APPPORT}" ]; then
+  echo "Using default APPPORT 5000"
+else
+   echo "Setting APPPORT: ${APPPORT}"
+    sed -i "s+APPPort = .*+APPPort = "${APPPORT}"+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer-UI/config.py
+  fi
+
+#WEBMAPIP
+if [ -z "${WEBMAPIP}" ]; then
+  echo "Using default WEBMAPIP 127.0.0.1"
+else
+   echo "Setting WEBMAPIP: ${WEBMAPIP}"
+    sed -i "s+WEBMAPIP = .*+WEBMAPIP = '"${WEBMAPIP}"'+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer-UI/config.py
+  fi
+
+#WEBMAPPROTOCOL
+if [ -z "${WEBMAPPROTOCOL}" ]; then
+  echo "Using default WEBMAPPROTOCOL http"
+else
+   echo "Setting WEBMAPPROTOCOL: ${WEBMAPPROTOCOL}"
+    sed -i "s+WEBMAPPROTOCOL = .*+WEBMAPPROTOCOL = '"${WEBMAPPROTOCOL}"'+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer-UI/config.py
+  fi
+
+#WEBMAPPORT
+if [ -z "${WEBMAPPORT}" ]; then
+  echo "Using default WEBMAPPORT 8000"
+else
+   echo "Setting WEBMAPPORT: ${WEBMAPPORT}"
+    sed -i "s+WEBMAPPORT = .*+WEBMAPPORT = "${WEBMAPPORT}"+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer-UI/config.py
   fi
 
 echo "###########################"


### PR DESCRIPTION
## Overview
This is a linked PR that improves configuration for more proposed FreeTAKServer-UI environment variables, and provides an example `docker-compose.yml` for these changes.

## Changes
- Allows changing `APPPORT` to host FTS UI from a different port, if needed
- Allows setting `APIPORT` and `APIPROTOCOL` for the FTS UI to specify a different API uri, if needed
- Adds additional `APIIP` config variable to set a separate API ip for the FTS UI than the FTS IP. If no `APIIP` is specified, it will use the `IP` value, if specified
- Allows setting `WEBMAPIP`, `WEBMAPPORT` and `WEBMAPPROTOCOL` for the FTS UI, if needed

## Related PRs
- Linked PR for [FreeTAKServer-UI](https://github.com/FreeTAKTeam/UI/pull/19) introducing more configuration options
- Linked PR for [FreeTAKServer-User-Docs](https://github.com/FreeTAKTeam/FreeTAKServer-User-Docs/pull/10) for these new variables

## Issues
- Partially addresses #24

The example `docker-compose.yml` can be split out into a separate PR if need be. Please don't hesitate to give feedback or commentary on these changes. Thank you!