### PR TITLE
Detect IP address assigned to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
 
 #APT
 RUN apt-get update && \
-    apt-get install -y libssl-dev libffi-dev curl python3 python3-pip libxml2-dev libxslt-dev python3-lxml python3-dev python3-setuptools build-essential &&\
+    apt-get install -y libssl-dev libffi-dev curl python3 python3-pip \
+            libxml2-dev libxslt-dev python3-lxml python3-dev \
+            python3-setuptools build-essential iproute2 &&\
     rm -rf /var/lib/apt/lists/*
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,6 @@ RUN sed -i 's+first_start = .*+first_start = False+g' /usr/local/lib/python3.8/d
 VOLUME ["/data"]
 COPY FTSConfig.yaml /opt/FTSConfig.yaml
 
-ENV IP=127.0.0.1
 ENV APPIP=0.0.0.0
 
 # Use non root user

--- a/start-fts.sh
+++ b/start-fts.sh
@@ -20,19 +20,21 @@ chmod -R 777 /data
 
 #IP
 if [ -z "${IP}" ]; then
-  echo "Using default IP 127.0.0.1"
+  ip=$(ip addr | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
+  echo "Using primary interface IP: $ip"
 else
-   echo "Setting IP: ${IP}"
-    sed -i "s+IP = .*+IP = '"${IP}"'+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer-UI/config.py
-  fi
+  echo "Setting IP: ${IP}"
+  ip=${IP}
+fi
+sed -i "s+IP = .*+IP = '"${ip}"'+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer-UI/config.py
 
 #APPIP
 if [ -z "${APPIP}" ]; then
   echo "Using default IP 127.0.0.1"
 else
-   echo "Setting APPIP: ${APPIP}"
-    sed -i "s+APPIP = .*+APPIP = '"${APPIP}"'+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer-UI/config.py
-  fi
+  echo "Setting APPIP: ${APPIP}"
+  sed -i "s+APPIP = .*+APPIP = '"${APPIP}"'+g" /usr/local/lib/python3.8/dist-packages/FreeTAKServer-UI/config.py
+fi
 
 echo "###########################"
 echo "Preparations completed"


### PR DESCRIPTION
If one follows the instructions contained in the `README.md`, the UI in the container fails with the following message:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/FreeTAKServer-UI/run.py", line 61, in <module>
    wsgi.server(sock = eventlet.listen((app_config.APPIP, app_config.APPPort)), site=app)
  File "/usr/local/lib/python3.8/dist-packages/eventlet/convenience.py", line 78, in listen
    sock.bind(addr)
OSError: [Errno 99] Cannot assign requested address
```

This is primarily due to the fact that the IP specified on the Docker command line is not assigned to the container unless `--network host` is used to override the default bridge network. Using the bridge network, it is not possible to know the IP address ahead of time to include it on the command line. 

This patch will allow the startup script to determine what IP was assigned to the container and then use that when starting up the UI. In addition, the previous behavior of specify the IP to bind to is preserved for backward compatibility (although I can not find a reason that it would need to be used given this patch). 

This patch would also be necessary when the container is fronted by a reverse proxy such at Traefik. 